### PR TITLE
chore: Add Github pages testing website

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -1,0 +1,32 @@
+name: Github Pages -> Algolia Crawler
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  algolia_recrawl:
+    name: Algolia Recrawl
+    runs-on: ubuntu-latest
+    steps:
+      # checkout this repo
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      # checkout the private repo containing the action to run
+      - name: Checkout GitHub Action Repo
+        uses: actions/checkout@v2
+        with:
+          repository: algolia/algoliasearch-crawler-github-actions 
+          ref: v0.4.2
+      - name: Sleep for 30s
+        run: sleep 30
+      - name: Github-pages-MAIN => Algolia crawler creation and recrawl (Push on Main branch)
+        uses: ./
+        id: crawler_push
+        with:
+          crawler-user-id: ${{ secrets.CRAWLER_USER_ID }}
+          crawler-api-key: ${{ secrets.CRAWLER_API_KEY }}
+          crawler-api-base-url: 'https://crawler-dev.algolia.com/api/1/'
+          crawler-name: gpages-github-actions-test-${{ github.ref }}
+          algolia-app-id: ${{ secrets.ALGOLIA_APP_ID }}
+          algolia-api-key: ${{ secrets.ALGOLIA_API_KEY }}
+          site-url: 'https://community.algolia.com/algoliasearch-crawler-github-actions/public/github-pages/'

--- a/public/github-pages/1.html
+++ b/public/github-pages/1.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>First test page</title>
+    <meta name="description" content="First test page description" />
+  </head>
+  <body>
+    <h2>First test page</h2>
+    <p>This is the contents of the first test page.</p>
+  </body>
+</html>

--- a/public/github-pages/2.html
+++ b/public/github-pages/2.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Second test page</title>
+    <meta name="description" content="Second test page description" />
+  </head>
+  <body>
+    <h2>Second test page</h2>
+    <p>This is the contents of the second test page.</p>
+  </body>
+</html>

--- a/public/github-pages/index.html
+++ b/public/github-pages/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Algoliasearch Github Pages Test Website</title>
+  <meta name="description" content="Algolia x Github Pages testing website." />
+
+  <link rel="icon" href="/favicon.ico" />
+</head>
+
+<body>
+  <h1>Algoliasearch Github Actions Test Website</h1>
+
+  <h2>Test content</h2>
+
+  <p>Some content to index.</p>
+  <p>Links to other pages:
+  <ul>
+    <li>
+      <a href="1.html">1.html</a>
+    </li>
+    <li>
+      <a href="2.html">2.html</a>
+    </li>
+  </ul>
+  </p>
+</body>
+
+</html>


### PR DESCRIPTION
I activated The Github Pages on the repo:
- It allows you to only choose one active branch (current it's this branch, then I'll change to main before merging) and a base directory which can be either `root` or `docs/ `so it will be root I guess (that's why the site url in the Action is https://community.algolia.com/algoliasearch-crawler-github-actions/public/github-pages/ )
- Unfortunately there's no online preview as Netlify and Vercel do (Github advise to test locally using Jekyll : https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll )
- That's why I only set an action on push on the main branch targetting the url above.

WDYT ?