### PR TITLE
fix: check if the comment exists or not before creating it.

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -441,8 +441,7 @@ function getRecordExtractorSource() {
     return "({ helpers }) => {\n  return helpers.netlifyExtractor({ template: 'default' });\n}";
 }
 function findCommentPredicate(crawlerId, comment) {
-    console.log(comment.user);
-    return ((comment.user ? comment.user.login === 'github-actions' : false) &&
+    return ((comment.user ? comment.user.login === 'github-actions[bot]' : false) &&
         (comment.body ? comment.body.includes(crawlerId) : false));
 }
 function findComment(prNumber, crawlerId) {

--- a/build/index.js
+++ b/build/index.js
@@ -510,6 +510,7 @@ function addComment(crawlerId) {
                 case 1:
                     comment = _a.sent();
                     if (comment !== undefined) {
+                        core.info('Existing comment found.');
                         return [2];
                     }
                     pathArray = CRAWLER_API_BASE_URL.split('/');

--- a/build/index.js
+++ b/build/index.js
@@ -441,6 +441,7 @@ function getRecordExtractorSource() {
     return "({ helpers }) => {\n  return helpers.netlifyExtractor({ template: 'default' });\n}";
 }
 function findCommentPredicate(crawlerId, comment) {
+    console.log(comment.user);
     return ((comment.user ? comment.user.login === 'github-actions' : false) &&
         (comment.body ? comment.body.includes(crawlerId) : false));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ function getRecordExtractorSource(): string {
 }
 
 function findCommentPredicate(crawlerId: string, comment: Comment): boolean {
+  console.log(comment.user);
   return (
     (comment.user ? comment.user.login === 'github-actions' : false) &&
     (comment.body ? comment.body.includes(crawlerId) : false)

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,9 +67,8 @@ function getRecordExtractorSource(): string {
 }
 
 function findCommentPredicate(crawlerId: string, comment: Comment): boolean {
-  console.log(comment.user);
   return (
-    (comment.user ? comment.user.login === 'github-actions' : false) &&
+    (comment.user ? comment.user.login === 'github-actions[bot]' : false) &&
     (comment.body ? comment.body.includes(crawlerId) : false)
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ async function addComment(crawlerId: string): Promise<void> {
     const comment = await findComment(prNumber, crawlerId);
 
     if (comment !== undefined) {
+      core.info('Existing comment found.');
       return;
     }
 


### PR DESCRIPTION
To prevent several messages to be created if a PR is edited, we search for the crawler Id (which is present in the link url) in the previous comments and we don't create another comment in such case. 