### PR TITLE
fix(action): use node12 runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,5 +41,5 @@ inputs:
     default: false
 
 runs:
-  using: 'node14'
+  using: 'node12'
   main: 'build/index.js'


### PR DESCRIPTION
Trying to use the Github Action, I got the following error:

```
 Download action repository 'algolia/algoliasearch-crawler-github-actions@v1.0.5' (SHA:8f979daf8292616c7283c72975066ec318ef82bb)
Error: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter ''using: node14' is not supported, use 'docker' or 'node12' instead.')
   at GitHub.Runner.Worker.ActionManifestManager.ConvertRuns(IExecutionContext executionContext, TemplateContext templateContext, TemplateToken inputsToken, String fileRelativePath, MappingToken outputs)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
Error: Fail to load algolia/algoliasearch-crawler-github-actions/v1.0.5/action.yml
```