### PR TITLE
update reference to support@algolia.com to new ticket link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ We highly recommend not to define sensitive information such as Algolia and/or C
 
 - Need help? We have you covered in our [Discourse forum](https://discourse.algolia.com/)
 - Found a bug in the plugin? Please read our [contributing guide](/CONTRIBUTING.md) and either open an [issue](https://github.com/algolia/algoliasearch-crawler-github-actions/issues) or a [pull request](https://github.com/algolia/algoliasearch-crawler-github-actions/pulls)
-- Can't find the answer to your issue? Please reach out to [support@algolia.com](support@algolia.com)
+- Can't find the answer to your issue? Please reach out to the [Algolia Support Team](https://alg.li/support).
 
 ## Development & Release
 


### PR DESCRIPTION
Hey team!
The Support team is currently in a process of removing [support@algolia.com](mailto:support@algolia.com) from all GitHub repos and updating it to the create support ticket link. We kindly ask that you review the changes made removing references to support@algolia.com.
Thanks!