### PR TITLE
fix: change `site-url` to a more generic example

### DIFF
--- a/examples/vercel_push.yml
+++ b/examples/vercel_push.yml
@@ -20,5 +20,5 @@ jobs:
           crawler-api-key: ${{ secrets.CRAWLER_API_KEY }}
           algolia-app-id: ${{ secrets.ALGOLIA_APP_ID }}
           algolia-api-key: ${{ secrets.ALGOLIA_API_KEY }}
-          site-url: 'https://algoliasearch-crawler-github-actions.vercel.app/'
+          site-url: 'https://crawler.algolia.com/test-website/'
           override-config: true


### PR DESCRIPTION
This PR changes the example url to a more generic url